### PR TITLE
- `fix`: error for qb drawtext

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -4,10 +4,10 @@ ps = {}
 Config.Inventory = "auto" -- auto, ox_inventory, qb-inventory, ps-inventory, lj-inventory, tgiann-inventory, jpr-inventory
 Config.Target = "auto" -- auto, ox_target, qb-target, interact
 Config.EmoteMenu = "rpemotes" -- rpemotes, dpemotes, scully, anything else for custom
-Config.Notify = "ox" -- qb, ox, ps, esx, mad_thoughts, okok, lation
+Config.Notify = "ox" -- qb, ox, ps, esx, mad_thoughts, okok, lation, okok, paradise
 Config.Menus = "ox" -- qb, ox, ps, lation
-Config.DrawText = "ox" -- qb, ox, ps, lation, okok 
-Config.Banking = "qb" -- qb, okok, Renewed, none
+Config.DrawText = "ox" -- qb, ox, ps, lation, okok
+Config.Banking = "qb" -- qb, okok, Renewed  
 Config.VehicleKeys = "qb" -- qb, mrnewb, none
 Config.ConvertQBMenu = false -- Convert qb-menu to ps-ui context menu and qb-input to ps-ui input
 

--- a/bridge/client.lua
+++ b/bridge/client.lua
@@ -36,6 +36,8 @@ local drawText = {
     ['qb'] = 'qb.lua',
     ['ox'] = 'ox.lua',
     ['ps'] = 'ps.lua',
+    ['lation'] = 'lation.lua',
+    ['okok'] = 'okok.lua',
 }
 
 local notify = {
@@ -44,6 +46,9 @@ local notify = {
     ['ps'] = 'client/ps.lua',
     ['esx'] = 'client/esx.lua',
     ['mad_thoughts'] = 'client/mad_thoughts.lua',
+    ['lation'] = 'client/lation.lua',
+    ['okok'] = 'client/okok.lua',
+    ['paradise'] = 'client/paradise.lua',
 }
 
 local progressbars = {
@@ -51,12 +56,14 @@ local progressbars = {
     ['oxbar'] = 'oxbar.lua',
     ['oxcircle'] = 'oxcircle.lua',
     ['keep'] = 'keep.lua',
+    ['lation'] = 'lation.lua',
 }
 
 local menus = {
     ['qb'] = 'qb.lua',
     ['ox'] = 'ox.lua',
     ['ps'] = 'ps.lua',
+    ['lation'] = 'lation.lua',
 }
 
 local vehicleKeys = {

--- a/bridge/drawtext/qb.lua
+++ b/bridge/drawtext/qb.lua
@@ -2,7 +2,7 @@ ps.success('Draw Text Module Loaded: QB-Core')
 
 function ps.drawText(text)
     if not text then return end
-    exports['qb-core']:ShowText(text)
+    exports['qb-core']:DrawText(text)
 end
 
 function ps.hideText()

--- a/bridge/framework/esx/server.lua
+++ b/bridge/framework/esx/server.lua
@@ -24,33 +24,6 @@ local function handleJobGrades(jobName)
     return grades
 end
 
-local function loadJobsCompat()
-    local result = MySQL.query.await('SELECT * FROM jobs',{})
-    for k, v in pairs(result) do
-        jobs[v.name] = {
-            label = v.label,
-            defaultDuty = false,
-            type = esxJOBCompat[v.name] or 'none',
-            offDutyPay = 0,
-            grades = handleJobGrades(v.name),
-        }
-    end
-end
-
-local function loadVehiclesCompat()
-    local result = MySQL.query.await('SELECT * FROM vehicles')
-    for k, v in pairs(result) do
-        vehicles[v.model] = {
-            name = v.name,
-            price = v.price,
-            category = v.category,
-        }
-    end
-end
-loadJobsCompat()
-loadVehiclesCompat()
-ps.Shared.Vehicles = vehicles
-ps.Shared.Jobs = jobs
 
 ps.registerCallback('ps_lib:esx:getVehicleLabel', function(model)
    MySQL.query.await('SELECT name FROM vehicles WHERE model = ?', {model}, function(result)
@@ -417,7 +390,7 @@ function ps.hasPermission(source, permission)
 end
 
 function ps.getSharedItems()
-    return exports.ox_inventory:GetItems()
+    return exports.ox_inventory:Items()
 end
 
 function ps.getItemLabel(item)
@@ -437,3 +410,31 @@ RegisterNetEvent('ps_lib:server:toggleDuty', function(bool)
     local src = source
     ps.setJobDuty(src, bool)
 end)
+
+local function loadJobsCompat()
+    local result = MySQL.query.await('SELECT * FROM jobs',{})
+    for k, v in pairs(result) do
+        jobs[v.name] = {
+            label = v.label,
+            defaultDuty = false,
+            type = esxJOBCompat[v.name] or 'none',
+            offDutyPay = 0,
+            grades = handleJobGrades(v.name),
+        }
+    end
+end
+
+local function loadVehiclesCompat()
+    local result = MySQL.query.await('SELECT * FROM vehicles')
+    for k, v in pairs(result) do
+        vehicles[v.model] = {
+            name = v.name,
+            price = v.price,
+            category = v.category,
+        }
+    end
+end
+loadJobsCompat()
+loadVehiclesCompat()
+ps.Shared.Vehicles = vehicles
+ps.Shared.Jobs = jobs

--- a/bridge/server.lua
+++ b/bridge/server.lua
@@ -19,6 +19,9 @@ local notify = {
     ['ps'] = 'server/ps.lua',
     ['esx'] = 'server/esx.lua',
     ['mad_thoughts'] = 'server/mad_thoughts.lua',
+    ['lation'] = 'server/lation.lua',
+    ['okok'] = 'server/okok.lua',
+    ['paradise'] = 'server/paradise.lua',
 }
 
 local banking = {

--- a/bridge/vehiclekeys/qb/client/client.lua
+++ b/bridge/vehiclekeys/qb/client/client.lua
@@ -13,4 +13,4 @@ function ps.removeVehicleKey(vehicle)
     TriggerEvent('qb-vehiclekeys:client:RemoveKeys', QBCore.Functions.GetPlate(vehicle))
 end
 
-ps.success('Vehicle Keys Module Loaded: MrNewb Vehicle Keys')
+ps.success('Vehicle Keys Module Loaded: QB Vehicle Keys')

--- a/changelog.txt
+++ b/changelog.txt
@@ -37,7 +37,7 @@ Build: 0.5.4
   - fix small ox_inventory bugs for stashes
   - added support for mad_thoughts and keep_progressbar
 
-Newest Build: 0.5.5
+Build: 0.5.5
   - added notification options
     - okok, lation, paradise
   - added inventory options
@@ -55,4 +55,9 @@ Newest Build: 0.5.5
   - added Lation Draw Text
   - added "or 'en'" to the langs global in config in case the native doesnt do it properly 
 
-  
+Newest Build: 0.5.6
+  - bug fixes:
+    - qb draw text error for DrawText. Mustache_dom was dumb and wrote ShowText
+    - crafting module destroyTarget fix if you arent running qb-target
+  - adjustments:
+    - added more the loader files to properly load notifications, draw text, menu modules for various resources

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,7 +5,7 @@ lua54 'yes'
 game 'gta5'
 
 name 'ps_lib'
-version '0.5.5'
+version '0.5.6'
 description 'Project Sloth Library'
 author 'Project Sloth'
 

--- a/modules/psui/client/crafter.lua
+++ b/modules/psui/client/crafter.lua
@@ -171,7 +171,7 @@ initTargets()
 
 RegisterNetEvent('ps_lib:registerCraftingLocation', function()
     for k, v in pairs(craftingNames) do
-        exports['qb-target']:RemoveZone(v)
+        ps.destroyTarget(v)
     end
     craftingNames = {}
     initTargets()

--- a/modules/versionCheck/server/versionCheck.lua
+++ b/modules/versionCheck/server/versionCheck.lua
@@ -13,6 +13,10 @@ function ps.versionCheck(script, link, updateLink)
     PerformHttpRequest(link, function(err, text, headers)
         local remoteVersion = nil
         local changelogLines = {}
+        if not text then
+            ps.error("Failed to fetch version info from " .. link .. " in Resource " .. script)
+            return
+        end
         for line in string.gmatch(text, "[^\r\n]+") do
             if not remoteVersion then
                 local match = string.match(line, "Newest Build:%s*(.+)")


### PR DESCRIPTION
- `fix`: error for ox target/interact on restart of a script that uses ps crafting
- `patch`: added missing filepaths for options and added options to config comments