### PR TITLE
check if there is data, if not send the entire table

### DIFF
--- a/bridge/framework/qbx/server.lua
+++ b/bridge/framework/qbx/server.lua
@@ -140,6 +140,11 @@ end
 --- @usage local jobData = ps.getJobData(source, 'dataKey')
 function ps.getJobData(source, data)
     local player = ps.getPlayer(source)
+    
+    if not data then
+        return player.PlayerData.job
+    end
+
     return player.PlayerData.job[data]
 end
 


### PR DESCRIPTION
fixed getJobData

it does return nil if getJobData only uses source, and is missing data, because it needs that data
this checks if there is data, if not send the entire job data